### PR TITLE
fix: Create generator using current device

### DIFF
--- a/ksampler_gpu.py
+++ b/ksampler_gpu.py
@@ -23,7 +23,7 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
         if "batch_index" in latent:
             batch_index = latent["batch_index"]
 
-        generator = torch.manual_seed(seed)
+        generator = torch.Generator(device=device).manual_seed(seed)
         for i in range(batch_index):
             noise = torch.randn([1] + list(latent_image.size())[1:], dtype=latent_image.dtype,
                                 layout=latent_image.layout, generator=generator, device=device)


### PR DESCRIPTION
I was running into an issue where the generator returned by `torch.manual_seed` was expecting a cpu device to be used with it. 

In researching the issue, I also discovered that this function sets the global seed and can have unintended consequences (see: https://github.com/huggingface/diffusers/issues/175)

This patch makes it so that a generator is created for use in this sampler, and it is configured to use the torch device returned by `get_torch_device`