### PR TITLE
fix: Generator

### DIFF
--- a/ksampler_gpu.py
+++ b/ksampler_gpu.py
@@ -23,7 +23,7 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
         if "batch_index" in latent:
             batch_index = latent["batch_index"]
 
-        generator = torch.manual_seed(seed)
+        generator = torch.Generator(device=device).manual_seed(seed) 
         for i in range(batch_index):
             noise = torch.randn([1] + list(latent_image.size())[1:], dtype=latent_image.dtype,
                                 layout=latent_image.layout, generator=generator, device=device)
@@ -74,7 +74,7 @@ def common_ksampler(model, seed, steps, cfg, sampler_name, scheduler, positive, 
         negative_copy += [[t] + n[1:]]
 
     models = get_models(positive) + get_models(negative)
-    comfy.model_management.load_controlnet_gpu(models)
+    comfy.model_management.load_models_gpu(models)
 
     if sampler_name in comfy.samplers.KSampler.SAMPLERS:
         sampler = comfy.samplers.KSampler(real_model, steps=steps, device=device, sampler=sampler_name,


### PR DESCRIPTION
This patch introduces the creation of a generator for use within this sampler. It is configured to utilize the Torch device returned by the `get_torch_device` function.

Thank you for addressing this issue, [nVitius](https://github.com/dawangraoming/ComfyUI_ksampler_gpu/pull/1).

The second issue encountered was:
The code attempts to invoke the `comfy.model_management.load_controlnet_gpu(models)` function, but the `comfy.model_management` module does not include the `load_controlnet_gpu` attribute.

The error occurred while executing KSamplerGPU:
`module 'comfy.model_management' has no attribute 'load_controlnet_gpu'`.

In the `Model_management.py` file, the `load_controlnet_gpu` function has been renamed to `load_models_gpu`.

For me, changing the function name resolved the problem.